### PR TITLE
remove go mod download before build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,6 @@ RUN mkdir -p /src
 WORKDIR /src
 
 COPY go.mod .
-
-RUN go mod download
 COPY . .
 
 ARG APP


### PR DESCRIPTION
go build will skip downloading the unnecessary library in `go.mod`.